### PR TITLE
Refresh watched summary on Details resume and add TV audio track selector

### DIFF
--- a/app/src/main/java/com/neo/neomovies/ui/details/DetailsScreen.kt
+++ b/app/src/main/java/com/neo/neomovies/ui/details/DetailsScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -49,6 +50,9 @@ import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -66,6 +70,17 @@ fun DetailsScreen(
         !prefs.getString("token", null).isNullOrBlank()
     }
     val watchedSummary = state.watchedSummary
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    DisposableEffect(lifecycleOwner, viewModel) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                viewModel.refreshWatchedSummary()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
 
     val waitForFavorite = isAuthorized && state.details != null && (state.isFavoriteLoading || state.isFavorite == null)
 

--- a/app/src/main/java/com/neo/neomovies/ui/details/DetailsViewModel.kt
+++ b/app/src/main/java/com/neo/neomovies/ui/details/DetailsViewModel.kt
@@ -103,6 +103,11 @@ class DetailsViewModel(
         }
     }
 
+    fun refreshWatchedSummary() {
+        val details = _state.value.details ?: return
+        _state.update { it.copy(watchedSummary = loadWatchedSummary(details)) }
+    }
+
     private fun refreshIsFavorite(details: MediaDetailsDto) {
         val (mediaId, suggestedType) = favoriteKey(details) ?: return
         _state.update { it.copy(isFavoriteLoading = true) }

--- a/app/src/tv/java/com/neo/tv/presentation/player/components/TvVideoPlayerControls.kt
+++ b/app/src/tv/java/com/neo/tv/presentation/player/components/TvVideoPlayerControls.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material.icons.filled.SkipPrevious
+import androidx.compose.material.icons.filled.VolumeUp
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
@@ -50,6 +51,7 @@ fun TvVideoPlayerControls(
     onShowControls: () -> Unit = {},
 ) {
     val focusRequester = remember { FocusRequester() }
+    var showAudioDialog by remember { mutableStateOf(false) }
     var showSubtitleDialog by remember { mutableStateOf(false) }
     var showQualityDialog by remember { mutableStateOf(false) }
     var isPlaying by remember { mutableStateOf(player.isPlaying) }
@@ -74,6 +76,15 @@ fun TvVideoPlayerControls(
             trackType = C.TRACK_TYPE_TEXT,
             viewModel = viewModel,
             onDismiss = { showSubtitleDialog = false },
+        )
+    }
+
+    if (showAudioDialog) {
+        TrackSelectionDialog(
+            title = stringResource(R.string.select_audio_track),
+            trackType = C.TRACK_TYPE_AUDIO,
+            viewModel = viewModel,
+            onDismiss = { showAudioDialog = false },
         )
     }
 
@@ -124,6 +135,14 @@ fun TvVideoPlayerControls(
                         if (player.hasNextMediaItem()) {
                             player.seekToNextMediaItem()
                         }
+                        onShowControls()
+                    },
+                )
+                TvVideoPlayerControlsIcon(
+                    icon = Icons.Default.VolumeUp,
+                    isPlaying = player.isPlaying,
+                    onClick = {
+                        showAudioDialog = true
                         onShowControls()
                     },
                 )


### PR DESCRIPTION
### Motivation
- Ensure the details screen shows up-to-date watch progress when the user returns to the screen. 
- Provide an audio track selection action in the TV player to match mobile behavior and allow choosing voice tracks.

### Description
- Added `refreshWatchedSummary()` to `DetailsViewModel` which recomputes `watchedSummary` from shared preferences using the existing `loadWatchedSummary` logic. 
- Hooked a lifecycle observer into `DetailsScreen` using `DisposableEffect` and `LocalLifecycleOwner` to call `viewModel.refreshWatchedSummary()` on `Lifecycle.Event.ON_RESUME`. 
- Added an audio track action to the TV player controls by introducing a `VolumeUp` icon button and a `TrackSelectionDialog` for `C.TRACK_TYPE_AUDIO` in `TvVideoPlayerControls.kt` so users can pick audio tracks.