### PR TITLE
Show movie watch progress on Details screen and refresh summary on resume

### DIFF
--- a/app/src/main/java/com/neo/neomovies/ui/details/DetailsScreen.kt
+++ b/app/src/main/java/com/neo/neomovies/ui/details/DetailsScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -49,6 +50,9 @@ import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -66,6 +70,17 @@ fun DetailsScreen(
         !prefs.getString("token", null).isNullOrBlank()
     }
     val watchedSummary = state.watchedSummary
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    DisposableEffect(lifecycleOwner, viewModel) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                viewModel.refreshWatchedSummary()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
 
     val waitForFavorite = isAuthorized && state.details != null && (state.isFavoriteLoading || state.isFavorite == null)
 
@@ -310,11 +325,11 @@ private fun DetailsBody(
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
+            val progress = if (summary.lastDuration > 0) {
+                ((summary.lastPosition.toFloat() / summary.lastDuration) * 100).toInt()
+            } else null
+            val progressSuffix = progress?.let { " • ${it}%" }.orEmpty()
             if (summary.lastSeason > 0 && summary.lastEpisode > 0) {
-                val progress = if (summary.lastDuration > 0) {
-                    ((summary.lastPosition.toFloat() / summary.lastDuration) * 100).toInt()
-                } else null
-                val progressSuffix = progress?.let { " • ${it}%" }.orEmpty()
                 Text(
                     text = stringResource(
                         R.string.details_last_watched,
@@ -325,6 +340,30 @@ private fun DetailsBody(
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
+            } else if (summary.lastPosition > 0) {
+                val positionMinutes = (summary.lastPosition / 60000).toInt()
+                if (summary.lastDuration > 0) {
+                    val durationMinutes = (summary.lastDuration / 60000).toInt()
+                    Text(
+                        text = stringResource(
+                            R.string.details_watch_progress_minutes,
+                            positionMinutes,
+                            durationMinutes,
+                            progressSuffix,
+                        ),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                } else {
+                    Text(
+                        text = stringResource(
+                            R.string.details_watch_progress_position,
+                            positionMinutes,
+                        ),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/neo/neomovies/ui/details/DetailsViewModel.kt
+++ b/app/src/main/java/com/neo/neomovies/ui/details/DetailsViewModel.kt
@@ -103,6 +103,11 @@ class DetailsViewModel(
         }
     }
 
+    fun refreshWatchedSummary() {
+        val details = _state.value.details ?: return
+        _state.update { it.copy(watchedSummary = loadWatchedSummary(details)) }
+    }
+
     private fun refreshIsFavorite(details: MediaDetailsDto) {
         val (mediaId, suggestedType) = favoriteKey(details) ?: return
         _state.update { it.copy(isFavoriteLoading = true) }

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -117,6 +117,8 @@
 
     <string name="details_watched_count">Просмотрено серий: %1$d</string>
     <string name="details_last_watched">Остановились: S%1$02dE%2$02d%3$s</string>
+    <string name="details_watch_progress_minutes">Остановились: %1$d/%2$d мин%3$s</string>
+    <string name="details_watch_progress_position">Остановились: %1$d мин</string>
 
     <string name="player_controls_play_pause">Воспроизведение / Пауза</string>
     <string name="player_controls_rewind">Перемотка назад</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -182,6 +182,8 @@
 
     <string name="details_watched_count">Watched series: %1$d</string>
     <string name="details_last_watched">Stopped at: S%1$02dE%2$02d%3$s</string>
+    <string name="details_watch_progress_minutes">Stopped at: %1$d/%2$d min%3$s</string>
+    <string name="details_watch_progress_position">Stopped at: %1$d min</string>
 
     <string name="picture_in_picture">Picture in picture</string>
     <string name="select_playback_speed">Select playback speed</string>

--- a/app/src/tv/java/com/neo/tv/presentation/player/components/TvVideoPlayerControls.kt
+++ b/app/src/tv/java/com/neo/tv/presentation/player/components/TvVideoPlayerControls.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material.icons.filled.SkipPrevious
+import androidx.compose.material.icons.filled.VolumeUp
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
@@ -50,6 +51,7 @@ fun TvVideoPlayerControls(
     onShowControls: () -> Unit = {},
 ) {
     val focusRequester = remember { FocusRequester() }
+    var showAudioDialog by remember { mutableStateOf(false) }
     var showSubtitleDialog by remember { mutableStateOf(false) }
     var showQualityDialog by remember { mutableStateOf(false) }
     var isPlaying by remember { mutableStateOf(player.isPlaying) }
@@ -74,6 +76,15 @@ fun TvVideoPlayerControls(
             trackType = C.TRACK_TYPE_TEXT,
             viewModel = viewModel,
             onDismiss = { showSubtitleDialog = false },
+        )
+    }
+
+    if (showAudioDialog) {
+        TrackSelectionDialog(
+            title = stringResource(R.string.select_audio_track),
+            trackType = C.TRACK_TYPE_AUDIO,
+            viewModel = viewModel,
+            onDismiss = { showAudioDialog = false },
         )
     }
 
@@ -124,6 +135,14 @@ fun TvVideoPlayerControls(
                         if (player.hasNextMediaItem()) {
                             player.seekToNextMediaItem()
                         }
+                        onShowControls()
+                    },
+                )
+                TvVideoPlayerControlsIcon(
+                    icon = Icons.Default.VolumeUp,
+                    isPlaying = player.isPlaying,
+                    onClick = {
+                        showAudioDialog = true
                         onShowControls()
                     },
                 )


### PR DESCRIPTION
### Motivation
- Ensure the Details screen displays watch progress for movies when episode/season info is unavailable. 
- Make sure the watched summary is refreshed when the user returns to the Details screen (on resume).
- Surface audio track selection in the TV player controls to match mobile behavior.

### Description
- Added a lifecycle observer in `DetailsScreen` using `DisposableEffect`/`LocalLifecycleOwner` to call `viewModel.refreshWatchedSummary()` on `Lifecycle.Event.ON_RESUME`.
- Implemented `refreshWatchedSummary()` in `DetailsViewModel` to recompute `watchedSummary` via existing `loadWatchedSummary` logic and update state.
- Updated `DetailsBody` UI to show minute-based watch progress when `lastSeason`/`lastEpisode` are absent by computing `positionMinutes`, `durationMinutes` and a percentage suffix and using new string resources.
- Added localized strings `details_watch_progress_minutes` and `details_watch_progress_position` in `values/strings.xml` and `values-ru/strings.xml` and added an audio track selector to TV controls by introducing a `VolumeUp` action and `TrackSelectionDialog` for `C.TRACK_TYPE_AUDIO` in `TvVideoPlayerControls.kt`.